### PR TITLE
Run gpg-agent with ssh-agent from .profile.

### DIFF
--- a/profile
+++ b/profile
@@ -10,4 +10,9 @@ config_dir="$HOME/.config/config_dir"
 
 export _JAVA_AWT_WM_NONREPARENTING=1
 
+if command -v gpg-agent > /dev/null; then
+	gpg-agent --daemon --enable-ssh-support > /dev/null 2>&1
+	export SSH_AUTH_SOCK="${HOME}/.gnupg/S.gpg-agent.ssh"
+fi
+
 # vi: ft=sh


### PR DESCRIPTION
This would start the gpg-agent from .profile and pretty much makes it available everywhere. Since gpg 2.1 the sockets created by gpg-agent have a default path in $HOME/.gnupg rather than a random path in /tmp, so no need to fiddle with environment variables anymore.