### PR TITLE
Use exa if available for file listing.

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,4 +1,6 @@
-if test_command gnuls; then
+if test_command exa; then
+	alias ls='exa --git -g'
+elif test_command gnuls; then
 	alias ls='gnuls --color=auto'
 elif test_command gls; then
 	alias ls='gls --color=auto'
@@ -9,7 +11,7 @@ fi
 alias lla='ls -alF --group-directories-first'
 alias ll='ls -lF --group-directories-first'
 alias la='ls -A --group-directories-first'
-alias l='ls -CF --group-directories-first'
+alias l='ls -F --group-directories-first'
 
 alias clip='xclip -i -selection clipboard'
 

--- a/zshrc
+++ b/zshrc
@@ -77,7 +77,7 @@ function count_hidden_files {
 function chpwd {
 	local count=$(count_files)
 	local hidden=$(count_hidden_files)
-	[ "$count" -le 50 ] && ls --group-directories-first -CF --color=always
+	[ "$count" -le 50 ] && ls --group-directories-first -F --color=always
 	echo "Files: $count, hidden: $hidden"
 }
 


### PR DESCRIPTION
Reasons to use `exa`:

- Colors; should I really say more?
- Shows git status when files / dirs are tracked.
- Option to ignore files listed in `.gitignore`.

With `exa`:
![Screenshot from 2019-11-12 10-21-26](https://user-images.githubusercontent.com/716138/68658688-342da180-0536-11ea-9408-ce39c4f94e7c.png)

Without `exa`:
![Screenshot from 2019-11-12 10-02-41](https://user-images.githubusercontent.com/716138/68657371-e3b54480-0533-11ea-866a-e8a6ec7a7e8d.png)

I removed the `-C`, because it doesn't exist in `exa` and it seems to be the default for `ls`, but let me know if this is something that is truly necessary.