### PR TITLE
Add alias for tree if exa is available.

### DIFF
--- a/aliases
+++ b/aliases
@@ -1,5 +1,6 @@
 if test_command exa; then
 	alias ls='exa --git -g'
+	alias tree='exa --tree -g'
 elif test_command gnuls; then
 	alias ls='gnuls --color=auto'
 elif test_command gls; then


### PR DESCRIPTION
This PR adds an alias for the `tree` command to use `exa` if it is available. It doesn't use `--git` because it is significantly slower and actually resulted in an error in some cases. Regardless, you can of course still run `tree --git` if you wish to see git status.